### PR TITLE
add filetype detection for neovim

### DIFF
--- a/filetype.vim
+++ b/filetype.vim
@@ -1,0 +1,3 @@
+augroup filetypedetect
+au BufNewFile,BufRead *.storm   setf storm
+augroup END


### PR DESCRIPTION
This causes neovim to create a new autocommand to associate *.storm files with the `storm` filetype.